### PR TITLE
Allow javadoc to fail without error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,9 @@
 						<goals>
 							<goal>jar</goal>
 						</goals>
+						<configuration>
+							<additionalparam>-Xdoclint:none</additionalparam>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>


### PR DESCRIPTION
This is needed for mvn package to work with java-8 as per http://stackoverflow.com/questions/15886209/maven-is-not-working-in-java-8-when-javadoc-tags-are-incomplete