### PR TITLE
revert #7 as it breaks jdk7 build support..

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,9 +137,6 @@
 						<goals>
 							<goal>jar</goal>
 						</goals>
-						<configuration>
-							<additionalparam>-Xdoclint:none</additionalparam>
-						</configuration>
 					</execution>
 				</executions>
 			</plugin>


### PR DESCRIPTION
I tried that already before.. but the flag introduced in #7 shall not be used as `-Xdoclint:none` is an invalid flag in javadoc in JDK 7 distros.. 

I'm not yet ready to ditch JDK 7 support completely.. not on workers that our first customer uses/needs..

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:2.9.1:jar (attach-javadocs) on project worker-base: MavenReportException: Error while creating archive:
[ERROR] Exit code: 1 - javadoc: error - invalid flag: -Xdoclint:none
[ERROR] 
[ERROR] Command line was: /usr/lib/jvm/java-7-oracle/jre/../bin/javadoc @options @packages
```