### PR TITLE
let system properties override all our properties..

### DIFF
--- a/src/main/java/com/github/libgraviton/workerbase/Worker.java
+++ b/src/main/java/com/github/libgraviton/workerbase/Worker.java
@@ -147,6 +147,9 @@ public class Worker {
                 this.properties.load(appProps);
                 appProps.close();
 
+                // let system properties override everything..
+                this.properties.putAll(System.getProperties());
+
                 LOG.info(" [*] Loaded app.properties from " + propertiesPath);
                 
             } catch (FileNotFoundException e) {


### PR DESCRIPTION
For Docker based deployment, we need to be able to override all the settings in the worker spefific `Properties` files with custom values on runtime. We do this by starting the container process with args like `java -Dgraviton.registerUrl=http://localhost:8000/event/worker/{workerId} -jar worker.jar`

Sadly, the stuff I did there (directly creating a `Properties`) ignores all system properties.. So I add them to overload. 

I'm sadly not aware of a Config library that does that *and* still gives the possibility to provide our workers with an old school `Properties` object. Most libraries replace the API and (understandably) don't offer a `Properties` instance. 