### PR TITLE
add multiple topics to a queue

### DIFF
--- a/src/main/java/com/github/libgraviton/workerbase/Worker.java
+++ b/src/main/java/com/github/libgraviton/workerbase/Worker.java
@@ -90,6 +90,7 @@ public class Worker {
         String queueName = channel.queueDeclare().getQueue();
 
         for (String bindKey : bindKeys) {
+            bindKey = bindKey.trim();
             channel.queueBind(queueName, exchangeName, bindKey);
             LOG.info("[*] Subscribed on topic exchange '" + exchangeName + "' using binding key '" + bindKey);
         }

--- a/src/main/java/com/github/libgraviton/workerbase/Worker.java
+++ b/src/main/java/com/github/libgraviton/workerbase/Worker.java
@@ -84,14 +84,16 @@ public class Worker {
         Channel channel = connection.createChannel();
 
         String exchangeName = this.properties.getProperty("queue.exchangeName");
-        String bindKey = this.properties.getProperty("queue.bindKey");
+        String[] bindKeys = this.properties.getProperty("queue.bindKey").split(",");
         
         channel.exchangeDeclare(exchangeName, "topic", true);
         String queueName = channel.queueDeclare().getQueue();
 
-        channel.queueBind(queueName, exchangeName, bindKey);
-
-        LOG.info("[*] Subscribed on topic exchange '" + exchangeName + "' using binding key '" + bindKey + "'. Waiting for messages...");
+        for (String bindKey : bindKeys) {
+            channel.queueBind(queueName, exchangeName, bindKey);
+            LOG.info("[*] Subscribed on topic exchange '" + exchangeName + "' using binding key '" + bindKey);
+        }
+        LOG.info("[*] Waiting for messages...");
 
         channel.basicQos(2);
         channel.basicConsume(queueName, true, this.getWorkerConsumer(channel, worker));

--- a/src/main/java/com/github/libgraviton/workerbase/Worker.java
+++ b/src/main/java/com/github/libgraviton/workerbase/Worker.java
@@ -10,6 +10,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URLDecoder;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Properties;
 
 import org.apache.commons.io.FilenameUtils;
@@ -84,13 +86,12 @@ public class Worker {
         Channel channel = connection.createChannel();
 
         String exchangeName = this.properties.getProperty("queue.exchangeName");
-        String[] bindKeys = this.properties.getProperty("queue.bindKey").split(",");
+        List<String> bindKeys = Arrays.asList(this.properties.getProperty("queue.bindKey").split(","));
         
         channel.exchangeDeclare(exchangeName, "topic", true);
         String queueName = channel.queueDeclare().getQueue();
 
         for (String bindKey : bindKeys) {
-            bindKey = bindKey.trim();
             channel.queueBind(queueName, exchangeName, bindKey);
             LOG.info("[*] Subscribed on topic exchange '" + exchangeName + "' using binding key '" + bindKey + "'");
         }

--- a/src/main/java/com/github/libgraviton/workerbase/Worker.java
+++ b/src/main/java/com/github/libgraviton/workerbase/Worker.java
@@ -92,7 +92,7 @@ public class Worker {
         for (String bindKey : bindKeys) {
             bindKey = bindKey.trim();
             channel.queueBind(queueName, exchangeName, bindKey);
-            LOG.info("[*] Subscribed on topic exchange '" + exchangeName + "' using binding key '" + bindKey);
+            LOG.info("[*] Subscribed on topic exchange '" + exchangeName + "' using binding key '" + bindKey + "'");
         }
         LOG.info("[*] Waiting for messages...");
 

--- a/src/main/java/com/github/libgraviton/workerbase/WorkerAbstract.java
+++ b/src/main/java/com/github/libgraviton/workerbase/WorkerAbstract.java
@@ -352,7 +352,7 @@ public abstract class WorkerAbstract {
         
         for (String subscriptionKey: subscriptionKeys) {
             WorkerRegisterSubscription subObj = new WorkerRegisterSubscription();
-            subObj.setEvent(subscriptionKey);
+            subObj.setEvent(subscriptionKey.trim());
             subscriptions.add(subObj);
         }
         

--- a/src/main/java/com/github/libgraviton/workerbase/WorkerAbstract.java
+++ b/src/main/java/com/github/libgraviton/workerbase/WorkerAbstract.java
@@ -352,7 +352,7 @@ public abstract class WorkerAbstract {
         
         for (String subscriptionKey: subscriptionKeys) {
             WorkerRegisterSubscription subObj = new WorkerRegisterSubscription();
-            subObj.setEvent(subscriptionKey.trim());
+            subObj.setEvent(subscriptionKey);
             subscriptions.add(subObj);
         }
         


### PR DESCRIPTION
This PR give us the ability to bind several topics on a queue. You can define a comma separated list of topics and subscriptions in the app.properties. The worker will notified for this events now.

`graviton.subscription=document.file.file.*,document.core.app.create`
`queue.bindKey=document.file.file.*,document.core.app.create`