### PR TITLE
add new eventResource field in EventStatus

### DIFF
--- a/src/main/java/com/github/libgraviton/workerbase/model/EventStatus.java
+++ b/src/main/java/com/github/libgraviton/workerbase/model/EventStatus.java
@@ -13,6 +13,7 @@ public class EventStatus {
     public String id;
     public String createDate;
     public String eventName;
+    public GravitonRef eventResource;
     public ArrayList<EventStatusStatus> status;
     public ArrayList<EventStatusInformation> information;
     
@@ -64,6 +65,18 @@ public class EventStatus {
     public void setEventName(String eventName) {
         this.eventName = eventName;
     }
+    /**
+     * <p>Getter for the field <code>eventResource</code>.</p>
+     *
+     * @return a {@link GravitonRef} object.
+     */
+    public GravitonRef getEventResource() { return eventResource; }
+    /**
+     * <p>Setter for the field <code>eventResource</code>.</p>
+     *
+     * @param eventResource a {@link GravitonRef} object.
+     */
+    public void setEventResource(GravitonRef eventResource) { this.eventResource = eventResource; }
     /**
      * <p>Getter for the field <code>status</code>.</p>
      *


### PR DESCRIPTION
needed to *not* overwrite the new field introduced in libgraviton/graviton#369 and handle the new field

@gfellerleonard after this, we should tag `0.11.0`! and bump the current workers to that new version..

