### PR TITLE
EVO-4790 (re)completing the $refs in the queueEvent-Object with prop gravitonBase.Url

### DIFF
--- a/src/main/java/com/github/libgraviton/workerbase/WorkerAbstract.java
+++ b/src/main/java/com/github/libgraviton/workerbase/WorkerAbstract.java
@@ -113,6 +113,14 @@ public abstract class WorkerAbstract {
         this.deliveryTag = deliveryTag;
         this.channel = channel;
 
+        // (re)completing the $refs in the queueEvent-Object with graviton.baseUrl property
+        queueEvent.getStatus().set$ref(
+                properties.getProperty("graviton.baseUrl") + queueEvent.getStatus().get$ref()
+        );
+        queueEvent.getDocument().set$ref(
+                properties.getProperty("graviton.baseUrl") + queueEvent.getDocument().get$ref()
+        );
+
         String statusUrl = queueEvent.getStatus().get$ref();
         try {
             processDelivery(queueEvent, statusUrl);

--- a/src/main/resources/default.properties
+++ b/src/main/resources/default.properties
@@ -7,7 +7,8 @@ queue.prefetchCount=2
 queue.connecting.retryAfterSeconds=10
 graviton.workerId=java-test
 #graviton.registerUrl=http://graviton-event-unstable.nova.scapp.io/event/worker/{workerId}
-graviton.registerUrl=http://localhost:8000/event/worker/{workerId}
-graviton.eventStatusBaseUrl=http://localhost:8000/event/status/
+graviton.baseUrl = http://apialias
+graviton.registerUrl=http://http://apialias/event/worker/{workerId}
+graviton.eventStatusBaseUrl=http://apialias/event/status/
 # can also be a comma separated list
 graviton.subscription=document.core.app.*

--- a/src/test/java/com/github/libgraviton/workerbase/WorkerBaseTest.java
+++ b/src/test/java/com/github/libgraviton/workerbase/WorkerBaseTest.java
@@ -8,6 +8,8 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 
+import java.util.Properties;
+import com.github.libgraviton.workerbase.helper.PropertiesLoader;
 import com.github.libgraviton.workerbase.model.QueueEvent;
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;
@@ -32,8 +34,11 @@ import com.github.libgraviton.workerbase.lib.TestWorkerNoAuto;
 @PrepareForTest({com.rabbitmq.client.ConnectionFactory.class,Unirest.class})
 public class WorkerBaseTest extends WorkerBaseTestCase {
 
+    private Properties properties;
+
     @Before
-    public void setUp() throws Exception {    
+    public void setUp() throws Exception {
+        properties = PropertiesLoader.load();
         this.baseMock();                    
     }
 
@@ -56,8 +61,8 @@ public class WorkerBaseTest extends WorkerBaseTestCase {
 
         QueueEvent queueEvent = testWorker.getHandledQueueEvent();
         assertEquals("documents.core.app.create", queueEvent.getEvent());
-        assertEquals("http://localhost/core/app/admin", queueEvent.getDocument().get$ref());
-        assertEquals("http://localhost/event/status/mystatus", queueEvent.getStatus().get$ref());
+        assertEquals(properties.getProperty("graviton.baseUrl") + "/core/app/admin", queueEvent.getDocument().get$ref());
+        assertEquals(properties.getProperty("graviton.baseUrl") + "/event/status/mystatus", queueEvent.getStatus().get$ref());
 
         // register
         verify(requestBodyMock, times(1)).body(contains("{\"id\":\"java-test\""));

--- a/src/test/resources/default.properties
+++ b/src/test/resources/default.properties
@@ -7,6 +7,7 @@ queue.prefetchCount=1
 queue.connecting.retryAfterSeconds=1
 graviton.workerId=java-test
 #graviton.registerUrl=http://graviton-event-unstable.nova.scapp.io/event/worker/{workerId}
-graviton.registerUrl=http://localhost:8000/event/worker/{workerId}
+graviton.baseUrl = http://apialias
+graviton.registerUrl=http://apialias/event/worker/{workerId}
 # can also be a comma separated list
 graviton.subscription=document.core.app.*

--- a/src/test/resources/json/queueEvent.json
+++ b/src/test/resources/json/queueEvent.json
@@ -1,5 +1,5 @@
 {
 "event": "documents.core.app.create",
-"status": {"$ref": "http://localhost/event/status/mystatus"},
-"document": {"$ref": "http://localhost/core/app/admin"}
+"status": {"$ref": "/event/status/mystatus"},
+"document": {"$ref": "/core/app/admin"}
 }


### PR DESCRIPTION
corresponding PR to https://github.com/libgraviton/graviton/pull/411

- The WorkerAbstract-Class completes the relative paths in the queueEvent-Object sent by Graviton.
- The paths to Graviton in the properties are starting with http://apialias
- Lets the derived workers do their job in Docker-Environment

**not backwards compatibel!**