### PR TITLE
set type of customerNumber to String

### DIFF
--- a/src/main/java/com/github/libgraviton/workerbase/model/GravitonCustomer.java
+++ b/src/main/java/com/github/libgraviton/workerbase/model/GravitonCustomer.java
@@ -12,7 +12,7 @@ public class GravitonCustomer {
     
     private String recordOrigin;
 
-    private Integer customerNumber;
+    private String customerNumber;
     
     /**
      * <p>Getter for the field <code>id</code>.</p>
@@ -56,7 +56,7 @@ public class GravitonCustomer {
      * @return a {@link java.lang.Integer} object.
      * @since 0.9.0
      */
-    public Integer getCustomerNumber() {
+    public String getCustomerNumber() {
         return customerNumber;
     }
 
@@ -66,7 +66,7 @@ public class GravitonCustomer {
      * @param customerNumber a {@link java.lang.Integer} object.
      * @since 0.9.0
      */
-    public void setCustomerNumber(Integer customerNumber) {
+    public void setCustomerNumber(String customerNumber) {
         this.customerNumber = customerNumber;
     }
 


### PR DESCRIPTION
being an int the customerNumber results always to 0, when set by a JSON-Conversion. 
This change is needed by the NIOS-Worker to write the correct customerNumber into its generated XML.