### PR TITLE
String property metadata.hash, getter and setter for metadata.hash

### DIFF
--- a/src/main/java/com/github/libgraviton/workerbase/model/file/Metadata.java
+++ b/src/main/java/com/github/libgraviton/workerbase/model/file/Metadata.java
@@ -14,6 +14,7 @@ public class Metadata {
     public String createDate;
     public String modificationDate;
     public String filename;
+    public String hash;
     public String additionalInformation;
     public List<MetadataAction> action;
     public List<MetadataAddProperty> additionalProperties;
@@ -99,6 +100,22 @@ public class Metadata {
         this.filename = filename;
     }
     /**
+     * <p>Getter for the field <code>hash</code>.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    public String getHash() {
+        return hash;
+    }
+    /**
+     * <p>Setter for the field <code>hash</code>.</p>
+     *
+     * @param hash a {@link java.lang.String} object.
+     */
+    public void setHash(String hash) {
+        this.hash = hash;
+    }
+    /**
      * <p>Getter for the field <code>action</code>.</p>
      *
      * @return a {@link java.util.List} object.
@@ -114,7 +131,6 @@ public class Metadata {
     public void setAction(List<MetadataAction> action) {
         this.action = action;
     }
-    
     /**
      * <p>Getter for the field <code>additionalInformation</code>.</p>
      *

--- a/src/test/java/com/github/libgraviton/workerbase/FileWorkerBaseTest.java
+++ b/src/test/java/com/github/libgraviton/workerbase/FileWorkerBaseTest.java
@@ -99,7 +99,9 @@ public class FileWorkerBaseTest extends WorkerBaseTestCase {
         assertEquals("2015-09-28T06:46:15+0000", testWorker.fileObj.metadata.getCreateDate());
         assertEquals("2015-09-28T06:46:15+0000", testWorker.fileObj.metadata.getModificationDate());
         assertEquals("hans.txt", testWorker.fileObj.metadata.getFilename());
-        
+        assertEquals("6129ec9222853b13723e07a2404091b9e8bbe6728e4836cd8a0ea06939e74fb7",
+                testWorker.fileObj.metadata.getHash());
+
         assertEquals(0, testWorker.fileObj.metadata.getAction().size());
         
         assertThat(testWorker.fileObj.getMetadata(), instanceOf(Metadata.class));
@@ -119,7 +121,7 @@ public class FileWorkerBaseTest extends WorkerBaseTestCase {
         workerConsumer.handleDelivery("document.file.file.create", envelope, new AMQP.BasicProperties(), message.getBytes());     
         
         verify(stringResponse, times(4)).getStatus();
-        
+
         assertEquals("16f52c4b00523e2ba27480ce6905ed1e", testWorker.fileObj.getId());
         
         // see action stuff

--- a/src/test/resources/json/fileResource.json
+++ b/src/test/resources/json/fileResource.json
@@ -7,6 +7,7 @@
     "mime": "image/jpeg",
     "filename": "hans.txt",
     "createDate": "2015-09-28T06:46:15+0000",
-    "modificationDate": "2015-09-28T06:46:15+0000"
+    "modificationDate": "2015-09-28T06:46:15+0000",
+    "hash": "6129ec9222853b13723e07a2404091b9e8bbe6728e4836cd8a0ea06939e74fb7"
   }
 }


### PR DESCRIPTION
Matching the new hash field in Metadata of file, introduced in Graviton > v0.58.0 https://github.com/libgraviton/graviton/releases/tag/v0.58.0