### PR TITLE
reconnect closed channel on handleShutdownSignal in WorkerConsumer

### DIFF
--- a/src/main/java/com/github/libgraviton/workerbase/Worker.java
+++ b/src/main/java/com/github/libgraviton/workerbase/Worker.java
@@ -10,7 +10,6 @@ import com.github.libgraviton.workerbase.exception.GravitonCommunicationExceptio
 import com.github.libgraviton.workerbase.exception.WorkerException;
 import com.github.libgraviton.workerbase.helper.PropertiesLoader;
 import com.github.libgraviton.workerbase.mq.QueueManager;
-import com.github.libgraviton.workerbase.mq.WorkerQueueManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -93,9 +92,7 @@ public class Worker {
     }
 
     public QueueManager getQueueManager() {
-        WorkerQueueManager workerQueueManager = new WorkerQueueManager(properties);
-        workerQueueManager.setWorker(worker);
-        return workerQueueManager;
+        return worker.getQueueManager();
     }
     
     /**

--- a/src/main/java/com/github/libgraviton/workerbase/WorkerAbstract.java
+++ b/src/main/java/com/github/libgraviton/workerbase/WorkerAbstract.java
@@ -16,6 +16,7 @@ import com.github.libgraviton.workerbase.model.status.EventStatus;
 import com.github.libgraviton.workerbase.model.status.InformationType;
 import com.github.libgraviton.workerbase.model.status.Status;
 import com.github.libgraviton.workerbase.model.status.WorkerFeedback;
+import com.github.libgraviton.workerbase.mq.WorkerQueueManager;
 import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.Unirest;
 import com.mashape.unirest.http.exceptions.UnirestException;
@@ -24,7 +25,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
 
 /**
  * <p>Abstract WorkerAbstract class.</p>
@@ -263,5 +267,11 @@ public abstract class WorkerAbstract {
         GravitonRef actionRef = new GravitonRef();
         actionRef.set$ref(gravitonBaseUrl + eventActionEndpoint + workerId + "-default");
         return actionRef;
+    }
+
+    public WorkerQueueManager getQueueManager() {
+        WorkerQueueManager workerQueueManager = new WorkerQueueManager(properties);
+        workerQueueManager.setWorker(this);
+        return workerQueueManager;
     }
 }

--- a/src/main/java/com/github/libgraviton/workerbase/WorkerConsumer.java
+++ b/src/main/java/com/github/libgraviton/workerbase/WorkerConsumer.java
@@ -66,7 +66,17 @@ public class WorkerConsumer extends DefaultConsumer {
 
     @Override
     public void handleShutdownSignal(String consumerTag, ShutdownSignalException sig) {
-        LOG.info("Lost connection to message queue '" + queueName + "'. Starting connection recovery.");
-    }
+        LOG.info("Lost connection to message queue '" + queueName + "'.");
+        if(sig.getReference() instanceof Channel) {
+            Channel channel = (Channel) sig.getReference();
+            Connection connection = channel.getConnection();
 
+            LOG.info("Channel is closed. Creating new channel for connection '" + connection + "'.");
+            try {
+                worker.getQueueManager().createChannel(connection);
+            } catch (IOException e) {
+                LOG.error("Cannot create channel for connection '" + connection + "'.", e);
+            }
+        }
+    }
 }

--- a/src/main/java/com/github/libgraviton/workerbase/mq/WorkerQueueConnector.java
+++ b/src/main/java/com/github/libgraviton/workerbase/mq/WorkerQueueConnector.java
@@ -40,16 +40,20 @@ public class WorkerQueueConnector extends QueueConnector {
     protected void connect() throws QueueConnectionException {
         try {
             Connection connection = factory.newConnection();
-            Channel channel = connection.createChannel();
-
-            Map<String, Object> arguments = null;
-            channel.queueDeclare(queueName, durable, exclusive, autoDelete, arguments);
-
-            channel.basicQos(prefetchCount);
-            channel.basicConsume(queueName, autoAck, new WorkerConsumer(channel, worker, queueName));
+            createChannel(connection);
         } catch (IOException | TimeoutException e) {
             throw new QueueConnectionException("Cannot connect to message queue.", queueName, e);
         }
+    }
+
+    public void createChannel(Connection connection) throws IOException {
+        Channel channel = connection.createChannel();
+
+        Map<String, Object> arguments = null;
+        channel.queueDeclare(queueName, durable, exclusive, autoDelete, arguments);
+
+        channel.basicQos(prefetchCount);
+        channel.basicConsume(queueName, autoAck, new WorkerConsumer(channel, worker, queueName));
     }
 
     @Override

--- a/src/main/java/com/github/libgraviton/workerbase/mq/WorkerQueueManager.java
+++ b/src/main/java/com/github/libgraviton/workerbase/mq/WorkerQueueManager.java
@@ -1,8 +1,10 @@
 package com.github.libgraviton.workerbase.mq;
 
 import com.github.libgraviton.workerbase.WorkerAbstract;
+import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
 
+import java.io.IOException;
 import java.util.Properties;
 
 /**
@@ -50,6 +52,10 @@ public class WorkerQueueManager extends QueueManager {
         queueConnector.setRetryAfterSeconds(retryAfterSeconds);
         queueConnector.setPrefetchCount(prefetchCount);
         return queueConnector;
+    }
+
+    public void createChannel(Connection connection) throws IOException {
+        ((WorkerQueueConnector) getQueueConnector()).createChannel(connection);
     }
 
     public void setWorker(WorkerAbstract worker) {


### PR DESCRIPTION
When sending a wrong delivery tag for a basic ack to the RabbitMQ, the connection channel will be closed for some reason and never recovers. This is among others due to the following design decision regarding automatic recovery for RabbitMQ.

> Automatic recovery only covers TCP connectivity issues and server-sent connection.close. It does not try to recover channels that were closed due to a channel exception or an application-level exception, by design.

We therefore need to re-establish the closed connection channel when the consumer gets notified that it was closed.