### PR TITLE
adapt logback config to truncate big log messages

### DIFF
--- a/src/main/java/com/github/libgraviton/workerbase/logging/TruncatedMessageConverter.java
+++ b/src/main/java/com/github/libgraviton/workerbase/logging/TruncatedMessageConverter.java
@@ -1,0 +1,31 @@
+package com.github.libgraviton.workerbase.logging;
+
+import ch.qos.logback.classic.pattern.ClassicConverter;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+
+/**
+ * <p>Allows to truncate the message size and add a postfix to mark the message visibly as truncated.</p>
+ *
+ * @author List of contributors {@literal <https://github.com/libgraviton/graviton-worker-base-java/graphs/contributors>}
+ * @see <a href="http://swisscom.ch">http://swisscom.ch</a>
+ * @version $Id: $Id
+ */
+public class TruncatedMessageConverter extends ClassicConverter {
+
+    @Override
+    public String convert(ILoggingEvent event) {
+        if(getOptionList().size() != 2) {
+            throw new IllegalArgumentException("Expected 2 arguments but got " + getOptionList().size() + ".");
+        }
+
+        int maxMessageLength = Integer.parseInt(getOptionList().get(0));
+        String postfix = getOptionList().get(1);
+        String message = event.getFormattedMessage();
+
+        if (message.length() >= maxMessageLength) {
+            message = message.substring(0, maxMessageLength) + " " + postfix;
+        }
+
+        return message;
+    }
+}

--- a/src/main/java/com/github/libgraviton/workerbase/logging/TruncatedMessageConverter.java
+++ b/src/main/java/com/github/libgraviton/workerbase/logging/TruncatedMessageConverter.java
@@ -3,6 +3,8 @@ package com.github.libgraviton.workerbase.logging;
 import ch.qos.logback.classic.pattern.ClassicConverter;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 
+import java.util.List;
+
 /**
  * <p>Allows to truncate the message size and add a postfix to mark the message visibly as truncated.</p>
  *
@@ -14,12 +16,12 @@ public class TruncatedMessageConverter extends ClassicConverter {
 
     @Override
     public String convert(ILoggingEvent event) {
-        if(getOptionList().size() != 2) {
+        if(getOptions().size() != 2) {
             throw new IllegalArgumentException("Expected 2 arguments but got " + getOptionList().size() + ".");
         }
 
-        int maxMessageLength = Integer.parseInt(getOptionList().get(0));
-        String postfix = getOptionList().get(1);
+        int maxMessageLength = Integer.parseInt(getOptions().get(0));
+        String postfix = getOptions().get(1);
         String message = event.getFormattedMessage();
 
         if (message.length() >= maxMessageLength) {
@@ -27,5 +29,12 @@ public class TruncatedMessageConverter extends ClassicConverter {
         }
 
         return message;
+    }
+
+    /**
+     * For some reason getOptionList() is protected. With getOptions() it's exposed and testable.
+     */
+    public List<String> getOptions() {
+        return getOptionList();
     }
 }

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
+
+  <conversionRule conversionWord="truncatedMsg"
+                  converterClass="com.github.libgraviton.workerbase.logging.TruncatedMessageConverter" />
+
   <appender name="file" class="ch.qos.logback.core.rolling.RollingFileAppender">
     <!--See also http://logback.qos.ch/manual/appenders.html#RollingFileAppender-->
     <File>logs/worker.log</File>
     <encoder>
-      <pattern>%d{ISO8601} %5p %c{1}:%L - %m%n</pattern>
+      <pattern>%date{ISO8601} [%thread] %5level %logger{1}:%line - %truncatedMsg{1000,[... truncated]}%n</pattern>
     </encoder>
     <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
       <level>debug</level>
@@ -19,7 +23,7 @@
   </appender>
   <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{ISO8601} %5p %c{1}:%L - %m%n</pattern>
+      <pattern>%date{ISO8601} [%thread] %5level %logger{1}:%line - %truncatedMsg{1000,[... truncated]}%n</pattern>
     </encoder>
   </appender>
   <root level="debug">

--- a/src/test/java/com/github/libgraviton/workerbase/logging/TruncatedMessageConverterTest.java
+++ b/src/test/java/com/github/libgraviton/workerbase/logging/TruncatedMessageConverterTest.java
@@ -1,0 +1,42 @@
+package com.github.libgraviton.workerbase.logging;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class TruncatedMessageConverterTest {
+
+    private TruncatedMessageConverter converter = spy(new TruncatedMessageConverter());
+
+    @Test
+    public void testSmallEnoughMessage() {
+        String message = "asdf";
+        String option1 = "10";
+        String option2 = "[... truncated]";
+
+        ILoggingEvent event = mock(ILoggingEvent.class);
+        when(event.getFormattedMessage()).thenReturn(message);
+        doReturn(Arrays.asList(option1, option2)).when(converter).getOptions();
+
+        String convertedMessege = converter.convert(event);
+        assertEquals(message, convertedMessege);
+    }
+
+    @Test
+    public void testTooBigMessage() {
+        String message = "asdf";
+        String option1 = "2";
+        String option2 = "[... truncated]";
+
+        ILoggingEvent event = mock(ILoggingEvent.class);
+        when(event.getFormattedMessage()).thenReturn(message);
+        doReturn(Arrays.asList(option1, option2)).when(converter).getOptions();
+
+        String convertedMessege = converter.convert(event);
+        assertEquals("as " + option2, convertedMessege);
+    }
+}


### PR DESCRIPTION
Limit max log message entry char length to 1000 chars and add a specific message formatter to allow a postfix message whenever a message got truncated.