### PR TITLE
bump messaging dependency to version 0.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>com.github.libgraviton</groupId>
             <artifactId>messaging</artifactId>
-            <version>0.2.0</version>
+            <version>0.3.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>


### PR DESCRIPTION
The new messaging dependency allows to send text messages via message queue in addition to bytes messages